### PR TITLE
Travis prep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,21 +17,7 @@ cache:
     - $HOME/.composer/cache
 
 matrix:
-  allow_failures:
-    - php: nightly
-    - env: WP_VERSION=trunk
-  fast_finish: true
   include:
-    - php: nightly
-      env: WP_VERSION=latest
-    - php: 7.1
-      env: WP_VERSION=latest
-    - php: 7.0
-      env: WP_VERSION=latest
-    - php: 5.6
-      env: WP_VERSION=latest
-    - php: 5.6
-      env: WP_VERSION=trunk
     - php: 5.6
       env: WP_TRAVISCI=phpcs
 
@@ -40,10 +26,6 @@ install: composer install --no-interaction --optimize-autoloader --prefer-dist
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - |
-    if [[ ! -z "$WP_VERSION" ]] ; then
-      bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
-    fi
-  - |
     if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
       composer global require wp-coding-standards/wpcs
       phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
@@ -51,10 +33,6 @@ before_script:
 
 script:
   - |
-    if [[ ! -z "$WP_VERSION" ]] ; then
-      phpunit
-    fi
-  - |
     if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
-      phpcs --standard=phpcs.ruleset.xml $(find . -name '*.php')
+      phpcs
     fi

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         "tijsverkoyen/css-to-inline-styles": "^2.0"
     },
     "require-dev": {
-        "psy/psysh": "^0.8",
-        "wp-coding-standards/wpcs": "^0.13"
+        "psy/psysh": "^0.8"
     },
     "autoload": {
         "classmap": ["src/"]

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "tijsverkoyen/css-to-inline-styles": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.7",
         "psy/psysh": "^0.8",
         "wp-coding-standards/wpcs": "^0.13"
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,8 +10,8 @@
     <arg name="extensions" value="php"/>
     <file>.</file>
 
-    <!-- Show sniff codes in all reports -->
-    <arg value="s"/>
+    <!-- Show progress and sniff codes in all reports -->
+    <arg value="ps"/>
 
     <exclude-pattern>*/tests/*</exclude-pattern>
     <exclude-pattern>*/vendor/*</exclude-pattern>


### PR DESCRIPTION
Favors globally installed testing tools and removes PHPUnit from travis scripts as no tests have been written yet